### PR TITLE
github-summary returns nothing when formatter value is an empty string

### DIFF
--- a/app/sagas/index.js
+++ b/app/sagas/index.js
@@ -6,7 +6,10 @@ import * as types from '../constants/ActionTypes';
 function* fetchSummary() {
   try {
     const settings = yield select(state => state.settings);
-    const githubSummary = new GithubSummary({ ...settings });
+    const params = { ...settings };
+    if (!params.formatter) delete params.formatter;
+
+    const githubSummary = new GithubSummary(params);
     const summary = yield call([githubSummary, githubSummary.getSummary]);
     yield put({ type: types.SUMMARY_FETCH_SUCCESS, payload: summary });
   } catch (err) {


### PR DESCRIPTION
#5 related

This could be the problem with github-summary plugin side.  Passing an empty string for `formatter` returns `""`, basically formatting it into nothing.
## TODOs
- [x] omit 'formatter' option from github-summary if formatter is an empty string
